### PR TITLE
Remove textAppearances and upgrade Material Components for Android

### DIFF
--- a/app/src/main/res/layout/menu_bottom_sheet_dialog_fragment.xml
+++ b/app/src/main/res/layout/menu_bottom_sheet_dialog_fragment.xml
@@ -58,7 +58,7 @@
             android:layout_gravity="center"
             android:text="@string/no_projects"
             android:textAlignment="center"
-            android:textAppearance="?attr/textAppearanceCaption"
+            android:textAppearance="?attr/textAppearanceBodySmall"
             android:visibility="gone" />
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/more_bottom_sheet_dialog_fragment.xml
+++ b/app/src/main/res/layout/more_bottom_sheet_dialog_fragment.xml
@@ -136,7 +136,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="·"
-            android:textAppearance="?attr/textAppearanceBody1"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
             android:textColor="@color/material_on_surface_emphasis_medium" />
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/task_fragment.xml
+++ b/app/src/main/res/layout/task_fragment.xml
@@ -90,7 +90,7 @@
                     android:ellipsize="end"
                     android:maxLines="1"
                     android:text="@{task.name}"
-                    android:textAppearance="?attr/textAppearanceSubtitle1"
+                    android:textAppearance="?attr/textAppearanceBodyLarge"
                     android:visibility="visible"
                     app:layout_collapseMode="pin"
                     tools:text="@tools:sample/lorem/random"

--- a/app/src/main/res/layout/tasks_fragment.xml
+++ b/app/src/main/res/layout/tasks_fragment.xml
@@ -136,6 +136,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="@string/no_tasks"
-            android:textAppearance="?attr/textAppearanceBody1" />
+            android:textAppearance="?attr/textAppearanceBodyLarge" />
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -15,19 +15,8 @@
         <item name="colorOnError">@color/colorOnError</item>
         <item name="colorOutline">@color/material_on_surface_stroke</item>
         <item name="android:colorBackground">@color/colorBackground</item>
-        <item name="textAppearanceHeadline1">@style/TextAppearance.ToDometer.Headline1</item>
-        <item name="textAppearanceHeadline2">@style/TextAppearance.ToDometer.Headline2</item>
-        <item name="textAppearanceHeadline3">@style/TextAppearance.ToDometer.Headline3</item>
-        <item name="textAppearanceHeadline4">@style/TextAppearance.ToDometer.Headline4</item>
-        <item name="textAppearanceHeadline5">@style/TextAppearance.ToDometer.Headline5</item>
-        <item name="textAppearanceHeadline6">@style/TextAppearance.ToDometer.Headline6</item>
-        <item name="textAppearanceBody1">@style/TextAppearance.ToDometer.Body1</item>
-        <item name="textAppearanceBody2">@style/TextAppearance.ToDometer.Body2</item>
-        <item name="textAppearanceSubtitle1">@style/TextAppearance.ToDometer.Subtitle1</item>
-        <item name="textAppearanceSubtitle2">@style/TextAppearance.ToDometer.Subtitle2</item>
-        <item name="textAppearanceCaption">@style/TextAppearance.ToDometer.Caption</item>
+
         <item name="textAppearanceOverline">@style/TextAppearance.ToDometer.Overline</item>
-        <item name="textAppearanceButton">@style/TextAppearance.ToDometer.Button</item>
 
         <item name="shapeAppearanceSmallComponent">
             @style/ShapeAppearance.ToDometer.SmallComponent

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -37,8 +37,6 @@
         <item name="textInputStyle">@style/Widget.ToDometer.TextInput</item>
         <item name="android:elegantTextHeight">true</item>
 
-        <item name="bottomSheetStyle">@style/Widget.MaterialComponents.BottomSheet</item>
-
         <!-- Material3 -->
         <item name="textAppearanceDisplayLarge">@style/TextAppearance.ToDometer.Material3.DisplayLarge</item>
         <item name="textAppearanceDisplayMedium">@style/TextAppearance.ToDometer.Material3.DisplayMedium</item>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ object Versions {
     const val ktLint = "0.42.1"
     const val ktxVersion = "1.6.0"
     const val lifecycle = "2.3.1"
-    const val materialComponents = "1.5.0-alpha03"
+    const val materialComponents = "1.5.0-alpha04"
     const val mockk = "1.10.6"
     const val navigation = "2.3.5"
     const val ossLicenses = "17.0.0"


### PR DESCRIPTION
## Changes
- Remove Material Theming text appearances and replace by new Material You attributes c306849 
- Upgrade Material Components for Android to 1.5.0-alpha04. Remove bottomSheetStyle declaration in `themes`. This version also fixes the BottomSheet enter animation using Android Navigation https://github.com/material-components/material-components-android/issues/2368 ea1307a